### PR TITLE
Update Links in Docs

### DIFF
--- a/docs/api-src/plugin-collab.md
+++ b/docs/api-src/plugin-collab.md
@@ -2,7 +2,7 @@
 
 This plugin used to support collaborative editing for milkdown.
 
-Please check the [collaborative editing guide](/collaborative-editing) to learn more.
+Please check the [collaborative editing guide](/docs/guide/collaborative-editing) to learn more.
 
 ```typescript
 import { collab, collabServiceCtx } from '@milkdown/plugin-collab';

--- a/docs/guide/collaborative-editing.md
+++ b/docs/guide/collaborative-editing.md
@@ -1,7 +1,7 @@
 # Collaborative Editing
 
 Milkdown supports collaborative editing powered by [Y.js](https://docs.yjs.dev/).
-We provide the [@milkdown/plugin-collab](/plugin-collab) plugin to help you use milkdown with yjs easily.
+We provide the [@milkdown/plugin-collab](/docs/api/plugin-collab) plugin to help you use milkdown with yjs easily.
 This plugin includes basic collaborative editing features like:
 
 -   Sync between clients.

--- a/docs/guide/interacting-with-editor.md
+++ b/docs/guide/interacting-with-editor.md
@@ -191,7 +191,7 @@ Editor.make()
     .use(listener);
 ```
 
-For more details about listener, please check [Using Listeners](/plugin-listener).
+For more details about listener, please check [Using Listeners](/docs/api/plugin-listener).
 
 ---
 

--- a/docs/guide/keyboard-shortcuts.md
+++ b/docs/guide/keyboard-shortcuts.md
@@ -20,4 +20,4 @@ Editor
 ```
 
 If there is no supported commands for the behavior you expect, you can write a [prosemirror keymap plugin](https://github.com/ProseMirror/prosemirror-keymap) to do this.
-You may need to read the [composable plugins](/composable-plugins) section to learn how to convert a prosemirror plugin into milkdown plugin.
+You may need to read the [composable plugins](/docs/plugin/composable-plugins) section to learn how to convert a prosemirror plugin into milkdown plugin.

--- a/docs/plugin/composable-plugins.md
+++ b/docs/plugin/composable-plugins.md
@@ -1,8 +1,8 @@
 # Composable Plugins
 
-In the previous section, we showed you how to create a plugin from scratch. Luckily, you don't need to do that in most cases. Milkdown provides a lot of helpers in [@milkdown/utils](/utils) to make it easier to create plugins. The **composable** here means that you can use the plugin in other plugins. For example, you can use a command plugin in a keymap plugin. This is a very common pattern in Milkdown.
+In the previous section, we showed you how to create a plugin from scratch. Luckily, you don't need to do that in most cases. Milkdown provides a lot of helpers in [@milkdown/utils](/docs/api/utils) to make it easier to create plugins. The **composable** here means that you can use the plugin in other plugins. For example, you can use a command plugin in a keymap plugin. This is a very common pattern in Milkdown.
 
-I'll show you some examples of how to use composable plugins. But I won't go into detail about the options and the usage of each plugin. You can find the details in the [API reference](/utils#composable).
+I'll show you some examples of how to use composable plugins. But I won't go into detail about the options and the usage of each plugin. You can find the details in the [API reference](/docs/api/utils#composable).
 
 ## Schema
 

--- a/docs/plugin/using-plugins.md
+++ b/docs/plugin/using-plugins.md
@@ -52,67 +52,67 @@ await editor.create();
 
 Milkdown provides the following official plugins:
 
-* [@milkdown/preset-commonmark](/preset-commonmark):
+* [@milkdown/preset-commonmark](/docs/api/preset-commonmark):
 
    Add [commonmark](https://commonmark.org/) syntax support.
 
-* [@milkdown/preset-gfm](/preset-gfm)
+* [@milkdown/preset-gfm](/docs/api/preset-gfm)
 
   Add [gfm](https://github.github.com/gfm/) syntax support.
 
-* [@milkdown/plugin-history](/plugin-history)
+* [@milkdown/plugin-history](/docs/api/plugin-history)
 
   Add undo & redo support.
 
-* [@milkdown/plugin-clipboard](/plugin-clipboard)
+* [@milkdown/plugin-clipboard](/docs/api/plugin-clipboard)
 
   Add markdown copy & paste support.
 
-* [@milkdown/plugin-cursor](/plugin-cursor)
+* [@milkdown/plugin-cursor](/docs/api/plugin-cursor)
 
   Add drop & gap cursor.
 
-* [@milkdown/plugin-listener](/plugin-listener)
+* [@milkdown/plugin-listener](/docs/api/plugin-listener)
 
   Add listener support.
 
-* [@milkdown/plugin-collab](/plugin-collab)
+* [@milkdown/plugin-collab](/docs/api/plugin-collab)
 
   Add collaborative editing support, powered by [yjs](https://docs.yjs.dev/).
 
-* [@milkdown/plugin-prism](/plugin-prism)
+* [@milkdown/plugin-prism](/docs/api/plugin-prism)
 
   Add [prism](https://prismjs.com/) support for code block highlight.
 
-* [@milkdown/plugin-math](/plugin-math)
+* [@milkdown/plugin-math](/docs/api/plugin-math)
 
   Add [LaTeX](https://en.wikipedia.org/wiki/LaTeX) support for math, powered by [Katex](https://katex.org/).
 
-* [@milkdown/plugin-tooltip](/plugin-tooltip)
+* [@milkdown/plugin-tooltip](/docs/api/plugin-tooltip)
 
   Add universal tooltip support.
 
-* [@milkdown/plugin-slash](/plugin-slash)
+* [@milkdown/plugin-slash](/docs/api/plugin-slash)
 
   Add universal slash commands support.
 
-* [@milkdown/plugin-emoji](/plugin-emoji)
+* [@milkdown/plugin-emoji](/docs/api/plugin-emoji)
 
   Add emoji shortcut support (something like `:+1:`), and use [twemoji](https://twemoji.twitter.com/) to display emoji.
 
-* [@milkdown/plugin-diagram](/plugin-diagram)
+* [@milkdown/plugin-diagram](/docs/api/plugin-diagram)
 
   Add [mermaid](https://mermaid-js.github.io/mermaid/#/) diagram support.
 
-* [@milkdown/plugin-indent](/plugin-indent)
+* [@milkdown/plugin-indent](/docs/api/plugin-indent)
 
   Add tab indent support.
 
-* [@milkdown/plugin-upload](/plugin-upload)
+* [@milkdown/plugin-upload](/docs/api/plugin-upload)
 
   Add drop and upload support.
 
-* [@milkdown/plugin-block](/plugin-block)
+* [@milkdown/plugin-block](/docs/api/plugin-block)
 
   Add a drag handle for every block node.
 

--- a/docs/recipes/nextjs.md
+++ b/docs/recipes/nextjs.md
@@ -1,6 +1,6 @@
 # Next.js
 
-Since we provide [react](/react) support out of box, we can use it directly in [Next.js](https://nextjs.org/).
+Since we provide [react](/docs/recipes/react) support out of box, we can use it directly in [Next.js](https://nextjs.org/).
 
 ## Install the Dependencies
 

--- a/docs/recipes/nuxtjs.md
+++ b/docs/recipes/nuxtjs.md
@@ -1,6 +1,6 @@
 # NuxtJS
 
-Since we provide [vue](/vue) support out of box, we can use it directly in [NuxtJS](https://v3.nuxtjs.org/).
+Since we provide [vue](/docs/recipes/vue) support out of box, we can use it directly in [NuxtJS](https://v3.nuxtjs.org/).
 
 > NuxtJS version should be 3.x.
 


### PR DESCRIPTION
Some of the links in the docs redirect to missing pages which were pretty confusing when trying to click them.

I don't know if they were intended though.