### PR TITLE
Remove blockView in plugin-block.md 

### DIFF
--- a/docs/api-src/plugin-block.md
+++ b/docs/api-src/plugin-block.md
@@ -42,12 +42,12 @@ You need to bind the block view to the plugin in `editor.config`.
 ```typescript
 import { Editor } from '@milkdown/core';
 
-import { block, blockView } from '@milkdown/plugin-block';
+import { block } from '@milkdown/plugin-block';
 
 Editor
   .make()
   .config((ctx) => {
-    ctx.set(blockView.key, {
+    ctx.set(block.key, {
       view: blockPluginView(ctx)
     })
   })


### PR DESCRIPTION
`blockView` is not exported from '@milkdown/plugin-block' anymore (it appears to be removed in https://github.com/Milkdown/milkdown/commit/1257cca06c1c48d968a1a2f95258c29219f23a80).

See https://github.com/Milkdown/website/blob/05d305f/src/components/playground-editor/usePlayground.ts#L140-L144 for a working example of the block plugin.