### PR TITLE
docs: fix typo

### DIFF
--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -37,7 +37,7 @@ import { Milkdown, useEditor } from "@milkdown/vue";
 import { commonmark } from "@milkdown/preset-commonmark";
 
 export default defineComponent({
-  name: "Milkdown",
+  name: "MilkdownEditor",
   components: {
     Milkdown,
   },


### PR DESCRIPTION
Setting the same component name causes circular references to the component