### PR TITLE
Fix 6 style problems.

### DIFF
--- a/src/components/header/desktop/TextButton.tsx
+++ b/src/components/header/desktop/TextButton.tsx
@@ -68,7 +68,7 @@ export const TextButton: FC<TextButtonProps> = ({ text, children }) => {
         {...getReferenceProps()}
         className={clsx(
           className,
-          active && "fill-nord-primary font-bold text-nord-primary",
+          active && "!fill-nord-primary font-bold !text-nord-primary",
         )}
       >
         <span className="text-sm">{text}</span>

--- a/src/components/header/mobile/index.tsx
+++ b/src/components/header/mobile/index.tsx
@@ -99,7 +99,7 @@ export const MobileNav: FC = () => {
           "transition-right duration-300",
         )}
       >
-        <div className="flex h-16 items-center justify-between border-b border-nord-neutral/10 px-2 dark:border-nord-neutral/10">
+        <div className="flex h-16 items-center justify-between border-b border-nord-neutral/10 px-2 dark:border-nord-neutral-dark/10">
           <div className="flex items-center gap-2" onClick={() => setScope("")}>
             {scope && (
               <button className="material-symbols-outlined">

--- a/src/components/liquid/index.tsx
+++ b/src/components/liquid/index.tsx
@@ -9,7 +9,7 @@ export const Liquid: FC<{ children: ReactNode }> = ({ children }) => {
       className={clsx(
         "liquid-cover",
         styles.cover,
-        "relative h-screen w-screen",
+        "relative h-screen",
         "bg-nord-background dark:bg-nord-background-dark",
       )}
     >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -75,7 +75,7 @@ export default function Home() {
             <h1
               className={clsx(
                 "text-center text-4xl font-bold text-nord-neutral dark:text-nord-neutral-dark sm:text-6xl xl:text-7xl",
-                "liquid-content opacity-0 delay-300",
+                "liquid-content liquid-delay-300 opacity-0",
               )}
             >
               Milkdown
@@ -86,7 +86,7 @@ export default function Home() {
                 "text-base sm:text-2xl",
                 "mt-6 mb-11 sm:mt-10 sm:mb-10",
                 "w-64 sm:w-full",
-                "liquid-content opacity-0 delay-500",
+                "liquid-content liquid-delay-500 opacity-0",
               )}
             >
               A plugin driven framework to build WYSIWYG Markdown editor.
@@ -94,7 +94,7 @@ export default function Home() {
             <div
               className={clsx(
                 "flex flex-col gap-4 sm:flex-row sm:gap-10",
-                "liquid-content opacity-0 delay-700",
+                "liquid-content liquid-delay-700 opacity-0",
               )}
             >
               <Link href={gettingStarted}>

--- a/src/providers/DarkModeProvider.tsx
+++ b/src/providers/DarkModeProvider.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext, useEffect, useState } from "react";
 
 import type { SetState } from "@/utils/types";
 
+const STORAGE_KEY = "darkMode";
+
 export const darkModeCtx = createContext<boolean>(false);
 export const setDarkModeCtx = createContext<SetState<boolean>>(() => undefined);
 
@@ -15,12 +17,25 @@ export const useSetDarkMode = () => {
 };
 
 export const DarkModeProvider: FC<{ children: ReactNode }> = ({ children }) => {
-  const [darkMode, setDarkMode] = useState(
-    typeof window !== "undefined" &&
-      window.matchMedia?.("(prefers-color-scheme: dark)").matches,
-  );
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window === "undefined") return false;
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return stored === "true";
+    }
+
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
 
   useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(darkMode));
+  }, [darkMode]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return;
+
     const media = window.matchMedia("(prefers-color-scheme: dark)");
     const listener = (event: MediaQueryListEvent) => {
       const newColorScheme = !!event.matches;

--- a/src/styles/crepe.css
+++ b/src/styles/crepe.css
@@ -20,10 +20,6 @@ div:not(.expanded) .crepe > .milkdown > .ProseMirror {
   @apply h-full px-32 py-12;
 }
 
-.crepe .milkdown:not(.expanded .crepe .milkdown) {
-  @apply overflow-y-scroll overscroll-none;
-}
-
 .cm-editor {
   @apply text-sm;
 }

--- a/src/styles/liquid.css
+++ b/src/styles/liquid.css
@@ -29,13 +29,13 @@
 
 .liquid-content {
   animation: fadeIn 0.5s ease var(--animation-delay) forwards;
-  &.delay-300 {
+  &.liquid-delay-300 {
     --animation-delay: 0.3s;
   }
-  &.delay-500 {
+  &.liquid-delay-500 {
     --animation-delay: 0.5s;
   }
-  &.delay-700 {
+  &.liquid-delay-700 {
     --animation-delay: 0.7s;
   }
 }


### PR DESCRIPTION
Introduce the problem details in the order of commit.

## 1. Remove horizontal scrollbar in home screen
![截屏2025-04-29 19 07 35](https://github.com/user-attachments/assets/fa2d7661-92b4-4ab2-bd00-1885ca75f0f0)
I remove `w-screen` from liquid style. It seems that it includes the vertical scrollbar width. By default, the block element expands horizontally, so it'ok to delete it.

## 2. Fix mobile nav border color
![截屏2025-04-29 19 12 29](https://github.com/user-attachments/assets/9234c516-0dc1-4dee-bf91-2edd7605c567)
It's hard to see the border here. I check the style and find `className="flex h-16 items-center justify-between border-b border-nord-neutral/10 px-2 dark:border-nord-neutral/10"`. It seems that it's a typo problem.

## 3. Fix active TextButton color
![截屏2025-04-29 19 15 27](https://github.com/user-attachments/assets/b81b02ae-a737-4634-ace4-3a04279f0339)
The active TextButton only has bolder style, but I fiind `text-nord-primary` is invalid. So I change it to `!text-nord-primary`.

## 4. Remove vertical scrollbar in editor
![截屏2025-04-29 19 18 17](https://github.com/user-attachments/assets/d6841c77-cb6e-4b40-903c-9cef8a9a710d)
I have thought it's kind of an ugly divider. But I find that it's an invalid scrollbar! So I delete it by removing `overflow-y-scroll overscroll-none;`. And I check that this is the only place to use the style, so it's ok to delete it.

## 5. Persist darkMode in localStorage
After I set the mode to light, it will go back to dark(default mode on my device) mode once refreshing.

## 6. Fix css name conflicts with tailwindcss
`delay-300` is also defined in tailwindcss, which is applied to every transition animation. That means, when you toggle the dark mode, or scale the window, it's also delayed. I don't this the prefered behavior. So I rename the class to make sure only the liquid animation is delayed.